### PR TITLE
fix typo: "Instalation" => "Installation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Small OAuth2 Access token helper.
 
-### Instalation
+### Installation
 
 ```bash
 $ npm install access-token


### PR DESCRIPTION
Just fixing a typo in the README — nothing crazy.
